### PR TITLE
feat: add IRSA support and serviceAccount creation

### DIFF
--- a/chart/templates/mattermost.yaml
+++ b/chart/templates/mattermost.yaml
@@ -225,7 +225,11 @@ spec:
     external:
       url: {{ .Values.fileStore.url | default .Values.minio.service.nameOverride }}
       bucket: {{ .Values.fileStore.bucket | default "mattermost" }}
+      {{- if .Values.fileStore.roleARN }}
+      useServiceAccount: true
+      {{- else }}
       secret: {{ .Values.fileStore.secret | default .Values.minio.secrets.name }}
+      {{- end }}
 
   {{/* If istio is hardened init containers won't work, see https://github.com/istio/istio/issues/23802 */}}
   {{/* This can be fixed if we have sidecar containers (https://github.com/kubernetes/enhancements/issues/753) or ambient mesh */}}

--- a/chart/templates/service-account.yaml
+++ b/chart/templates/service-account.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.fileStore.roleARN }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    eks.amazonaws.com/role-arn: {{ .Values.fileStore.roleARN}}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -277,6 +277,8 @@ fileStore:
   url: ""
   # Bucket for existing file store, leave empty for chart created minio
   bucket: ""
+  # ARN  of an IAM role to use.  Populate this when using Iam Roles for Service Accounts (IRSA)
+  roleARN: ""
 
 elasticsearch:
   # NOTE: Elasticsearch settings can be defined, but will not work unless enterprise mode is enabled.


### PR DESCRIPTION
Adds IAM Roles for Service Accounts (IRSA) support to the Big Bang Mattermost Add on.

If `fileStore.roleARN` is provided, the chart will create a service account with the required annotation.  
It also sets the `useServiceAccount` value in the Mattermost installation CR.
 